### PR TITLE
Fix style modal

### DIFF
--- a/src/containers/Event/Event.css
+++ b/src/containers/Event/Event.css
@@ -15,6 +15,8 @@
   bottom: 40px;
   left: 40px;
   right: 40px;
+  display: flex;
+  flex-direction: column;
   border-radius: 15px;
   z-index: 1000;
   transition: 0.2s linear;
@@ -32,22 +34,18 @@
 }
 
 .NavBar {
-  z-index: 1002;
-  position: fixed;
-  top: 40px;
-  left: 40px;
-  right: 40px;
-  border-top-left-radius: 12px;
-  border-top-right-radius: 12px;
+  height: 60px;
+  width: 100%;
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
   border: white 1px solid;
   display: flex;
   flex-direction: row;
 }
 
 .Tab-Panel{
-  position: relative;
-  padding-top: 80px;
   width: 100%;
-  height: auto;
+  height: 100%;
   background-color: white;
+  overflow-y: auto;
 }

--- a/src/containers/Event/Rooms/Rooms.js
+++ b/src/containers/Event/Rooms/Rooms.js
@@ -40,7 +40,8 @@ function Rooms() {
           item
           xs={12}
           spacing={2}
-          style={{ margin: "10px", marginRight: "15px" }}
+          justify="center"
+          style={{ margin: "10px" }}
         >
           {rooms.map((room) => (
             <Grid item container xs={3} key={room.roomId} spacing={1}>


### PR DESCRIPTION
Just some improvements for the scroll in the `Tap-Panel` component, and also the grid which contains all the rooms is now center aligned.

**PREVIOUS**
<img width="1440" alt="Screenshot 2020-04-13 at 16 22 02" src="https://user-images.githubusercontent.com/4621567/79127992-1a251300-7da3-11ea-9ca1-0d3369ebff95.png">

**FINAL RESULT**
<img width="1440" alt="Screenshot 2020-04-13 at 16 20 13" src="https://user-images.githubusercontent.com/4621567/79128245-7c7e1380-7da3-11ea-87b2-d45641c0a0c9.png">
