### PR TITLE
Disable Jitsi pre-join page

### DIFF
--- a/src/containers/Event/VideoChat/VideoChat.js
+++ b/src/containers/Event/VideoChat/VideoChat.js
@@ -38,6 +38,7 @@ function VideoChat({ isMenuOpen }) {
           },
           configOverwrite: {
             disableSimulcast: false,
+            prejoinPageEnabled: false,
           },
           userInfo: {
             displayName: currentUser.userName,


### PR DESCRIPTION
One of the newest features included in Jitsi Meet is the [pre-join page](https://community.jitsi.org/t/how-to-how-do-i-use-the-prejoin-page/73326). The goal of this PR is to restore VirtualDojo previous behaviour and disable this feature.

Users will join instantly any meet while using VirtualDojo.
